### PR TITLE
Fix spec to the method "format_hash" of Lumberg::Whm::Server 

### DIFF
--- a/spec/whm/server_spec.rb
+++ b/spec/whm/server_spec.rb
@@ -57,7 +57,7 @@ module Lumberg
 
     describe "#format_hash" do
       it "raises an error if hash is not a string" do
-        expect{  Whm::Server.new(:host => @whm_host, :hash => nil) }.
+        expect{  Whm::Server.new(:host => @whm_host, :hash => 1) }.
           to raise_error(Lumberg::WhmArgumentError, "Missing WHM hash")
       end
 


### PR DESCRIPTION
Hey guys,

I downloaded the lumberg project to an overview then I ran the tests and I saw an error so I tried to fix.

The first error was because a break line:

``` ruby
expect { foo }.to
  anything

# This don't work because we are calling the method "to" without any argument.

expect { foo }.
  to anything

# This work well
```

The second and last error was because when a hash is nil the initialize of `Lumberg::Whm::Server` already handle with that so I changed the hash to 1 in the spec and it returned to work.
