### PR TITLE
Replaces magical methods with proper implementation

### DIFF
--- a/lib/lumberg/whm/server.rb
+++ b/lib/lumberg/whm/server.rb
@@ -128,6 +128,18 @@ module Lumberg
         perform_request('reboot', {:key => "reboot"})
       end
 
+      def account
+        @account ||= Account.new(:server => self)
+      end
+
+      def dns
+        @dns ||= Dns.new(:server => self)
+      end
+
+      def reseller
+        @reseller ||= Reseller.new(:server => self)
+      end
+
     private
 
       def do_request(uri, function, params)
@@ -186,27 +198,6 @@ module Lumberg
         raise Lumberg::WhmArgumentError.new("Missing WHM hash") unless hash.is_a?(String)
         hash.gsub(/\n|\s/, '')
       end
-
-      # Creates WHM::Whatever.new(:server => @server)
-      # automagically
-      def auto_accessors
-        [:account, :dns, :reseller]
-      end
-
-      def method_missing(meth, *args, &block)
-        if auto_accessors.include?(meth.to_sym)
-          ivar = instance_variable_get("@#{meth}")
-          if ivar.nil?
-            constant = Whm.const_get(meth.to_s.capitalize)
-            return instance_variable_set("@#{meth}", constant.new(:server => self))
-          else
-            return ivar
-          end
-        else
-          super
-        end
-      end
-
     end
   end
 end

--- a/spec/whm/server_spec.rb
+++ b/spec/whm/server_spec.rb
@@ -188,19 +188,18 @@ module Lumberg
         @whm.account.should be_an(Whm::Account)
       end
 
-      it "returns the same thing twice" do
-        @whm.account.should be_a(Whm::Account)
-        @whm.account.should respond_to(:list)
-
-        @whm.account.should be_a(Whm::Account)
-        @whm.account.should respond_to(:list)
+      it "sets the server" do
+        @whm.account.server.should == @whm
       end
-
     end
 
     describe "#dns" do
       it "has an dns accessor" do
         @whm.dns.should be_an(Whm::Dns)
+      end
+
+      it "sets the server" do
+        @whm.dns.server.should == @whm
       end
     end
 
@@ -208,17 +207,9 @@ module Lumberg
       it "has an reseller accessor" do
         @whm.reseller.should be_an(Whm::Reseller)
       end
-    end
 
-    describe "#method_missing" do
-      it "caches @vars" do
-        Whm.should_receive(:const_get).once.and_return(Whm::Account)
-        @whm.account
-        @whm.account
-      end
-
-      it "raises to super" do
-        expect { @whm.asdf }.to raise_error(NoMethodError)
+      it "sets the server" do
+        @whm.reseller.server.should == @whm
       end
     end
 


### PR DESCRIPTION
Relying on method_missing hides the implementation and makes it not work with respond_to. I'm aware that that could be solved implementing respond_to, but this seems much simpler.

![Masked Magician](http://www.danny-stueber.com/sitebuildercontent/sitebuilderpictures/masked.jpg)
