### PR TITLE
Add CPanel Email MX options - change_mx and add_mx

### DIFF
--- a/lib/lumberg/cpanel/email.rb
+++ b/lib/lumberg/cpanel/email.rb
@@ -105,6 +105,38 @@ module Lumberg
         }.merge(options))
       end
 
+      # Public: Change values for a specific MX record
+      #
+      # options - Hash options for API call params (default: {}):
+      #   :domain        - String domain for the MX record you wish to change.
+      #   :exchange      - String name of the new exchanger.
+      #   :oldexchange   - String name of the exchanger to replace (optional).
+      #   :oldpreference - Integer priority value of the old exchanger.
+      #   :preference    - Integer priority value for the new exchange.
+      #   :alwaysaccept  - String setting to define behavior for the exchanger.
+      #                    Accepted: "backup", "local", "secondary", "remote".
+      #                    (optional)
+      #
+      # Returns Hash API response.
+      def change_mx(options = {})
+        perform_request({ :api_function => "changemx" }.merge(options))
+      end
+
+      # Public: Add an MX record
+      #
+      # options - Hash options for API call params (default: {}):
+      #   :domain       - String domain for the MX record you wish to change.
+      #   :exchange     - String name of the new exchanger.
+      #   :preference   - Integer priority value for the new exchange.
+      #   :alwaysaccept - String setting to define behavior for the exchanger.
+      #                   Accepted: "backup", "local", "secondary", "remote".
+      #                   (optional)
+      #
+      # Returns Hash API response.
+      def add_mx(options = {})
+        perform_request({ :api_function => "addmx" }.merge(options))
+      end
+
       # Public: Get list of mail exchanger information.
       #
       # options - Hash options for API call params (default: {}):

--- a/lib/lumberg/whm/dns.rb
+++ b/lib/lumberg/whm/dns.rb
@@ -131,6 +131,30 @@ module Lumberg
         server.perform_request('resetzone', options)
       end
 
+      # This function will change a specified domain's MX records
+      #
+      # ==== Required
+      #  * <tt>:domain</tt>        - PENDING
+      #  * <tt>:exchange</tt>      - PENDING
+      #  * <tt>:oldexchange</tt>   - PENDING
+      #  * <tt>:oldpreference</tt> - PENDING
+      #  * <tt>:preference</tt>    - PENDING
+      #  * <tt>:alwaysaccept</tt>  - PENDING
+      def change_mx(options = {})
+        server.perform_request('changemx', options.merge(:key => 'data'))
+      end
+
+      # This function will add an MX record to a  specified domain
+      #
+      # ==== Required
+      #  * <tt>:domain</tt>        - PENDING
+      #  * <tt>:exchange</tt>      - PENDING
+      #  * <tt>:preference</tt>    - PENDING
+      #  * <tt>:alwaysaccept</tt>  - PENDING
+      def add_mx(options = {})
+        server.perform_request('addmx', options.merge(:key => 'data'))
+      end
+
       # This function will list a specified domain's MX records
       #
       # *This function is only available in version 11.27/11.28+*

--- a/spec/cpanel/email_spec.rb
+++ b/spec/cpanel/email_spec.rb
@@ -234,6 +234,31 @@ module Lumberg
       end
     end
 
+    describe "#add_mx" do
+      use_vcr_cassette("cpanel/email/add_mx")
+
+      it "adds an mx record" do
+        email.add_mx(
+          :domain     => domain,
+          :exchange   => "mail.#{domain}",
+          :preference => 2
+        )[:params][:data][0][:status].should eq(1)
+      end
+    end
+
+    describe "#change_mx" do
+      use_vcr_cassette("cpanel/email/change_mx")
+
+      it "changes an existing mx record" do
+        email.add_mx(
+          :domain        => domain,
+          :exchange      => "mail.#{domain}",
+          :oldpreference => 2,
+          :preference    => 1
+        )[:params][:data][0][:status].should eq(1)
+      end
+    end
+
     describe "#mx" do
       use_vcr_cassette("cpanel/email/mx")
 

--- a/spec/vcr_cassettes/cpanel/email/add_mx.yml
+++ b/spec/vcr_cassettes/cpanel/email/add_mx.yml
@@ -1,0 +1,40 @@
+--- 
+recorded_with: VCR 2.0.1
+http_interactions: 
+- request: 
+    method: get
+    uri: https://myhost.com:2087/json-api/cpanel?cpanel_jsonapi_apiversion=2&cpanel_jsonapi_func=addmx&cpanel_jsonapi_module=Email&cpanel_jsonapi_user=lumberg&domain=lumberg-test.com&exchange=mail.lumberg-test.com&preference=2
+    body: 
+      string: ""
+    headers: 
+      User-Agent: 
+      - Faraday v0.8.7
+      Accept: 
+      - "*/*"
+      Authorization: 
+      - WHM root:iscool
+  response: 
+    status: 
+      code: 200
+      message: OK
+    headers: 
+      X-Keep-Alive-Count: 
+      - "1"
+      Date: 
+      - Fri, 24 May 2013 17:40:26 GMT
+      Content-Length: 
+      - "474"
+      Connection: 
+      - Keep-Alive
+      Keep-Alive: 
+      - timeout=70, max=200
+      Content-Type: 
+      - text/plain; charset="utf-8"
+      Server: 
+      - cpsrvd/11.32.6.4
+    body: 
+      string: |
+        {"cpanelresult":{"module":"Email","apiversion":2,"func":"addmx","data":[{"status":1,"statusmsg":"Reusing existing entry on line matched new entry and new priority: 29:\nNo dns changes are required","results":"Reusing existing entry on line matched new entry and new priority: 29:\nNo dns changes are required","checkmx":{"local":1,"isprimary":1,"remote":0,"warnings":[],"secondary":0,"issecondary":0,"changed":1,"detected":"local","mxcheck":"auto"}}],"event":{"result":1}}}
+
+    http_version: 
+  recorded_at: Fri, 24 May 2013 17:40:26 GMT

--- a/spec/vcr_cassettes/cpanel/email/change_mx.yml
+++ b/spec/vcr_cassettes/cpanel/email/change_mx.yml
@@ -1,0 +1,40 @@
+--- 
+recorded_with: VCR 2.0.1
+http_interactions: 
+- request: 
+    method: get
+    uri: https://myhost.com:2087/json-api/cpanel?cpanel_jsonapi_apiversion=2&cpanel_jsonapi_func=addmx&cpanel_jsonapi_module=Email&cpanel_jsonapi_user=lumberg&domain=lumberg-test.com&exchange=mail.lumberg-test.com&oldpreference=2&preference=1
+    body: 
+      string: ""
+    headers: 
+      Authorization: 
+      - WHM root:iscool
+      User-Agent: 
+      - Faraday v0.8.7
+      Accept: 
+      - "*/*"
+  response: 
+    status: 
+      code: 200
+      message: OK
+    headers: 
+      Connection: 
+      - Keep-Alive
+      Content-Length: 
+      - "474"
+      Date: 
+      - Fri, 24 May 2013 17:40:44 GMT
+      Content-Type: 
+      - text/plain; charset="utf-8"
+      Server: 
+      - cpsrvd/11.32.6.4
+      Keep-Alive: 
+      - timeout=70, max=200
+      X-Keep-Alive-Count: 
+      - "1"
+    body: 
+      string: |
+        {"cpanelresult":{"apiversion":2,"func":"addmx","module":"Email","data":[{"checkmx":{"remote":0,"isprimary":1,"local":1,"warnings":[],"detected":"local","issecondary":0,"secondary":0,"mxcheck":"auto","changed":1},"status":1,"statusmsg":"Reusing existing entry on line matched new entry and new priority: 28:\nNo dns changes are required","results":"Reusing existing entry on line matched new entry and new priority: 28:\nNo dns changes are required"}],"event":{"result":1}}}
+
+    http_version: 
+  recorded_at: Fri, 24 May 2013 17:40:44 GMT


### PR DESCRIPTION
Adds support for the cPanel API calls: [changemx](http://docs.cpanel.net/twiki/bin/view/ApiDocs/Api2/ApiEmail#Email::changemx) and [addmx](http://docs.cpanel.net/twiki/bin/view/ApiDocs/Api2/ApiEmail#Email::addmx) 
