### PR TITLE
Add set_mx_type and del_mx to Lumberg::Cpanel::Email

### DIFF
--- a/lib/lumberg/cpanel/email.rb
+++ b/lib/lumberg/cpanel/email.rb
@@ -149,6 +149,31 @@ module Lumberg
         }.merge(options))
       end
 
+      # Public: Delete an MX record
+      #
+      # options - Hash options for API call params (default: {}):
+      #   :domain       - String domain for the MX record you wish to change.
+      #   :exchange     - String name of the new exchanger.
+      #   :preference   - Integer priority value for the new exchange.
+      #
+      # Returns Hash API response.
+      def delete_mx(options = {})
+        perform_request({ :api_function => "delmx" }.merge(options))
+      end
+
+      # Public: Set a mail exchanger for a specified domain to local,
+      # remote, secondary, or auto
+      #
+      # options - Hash options for API call params (default: {}):
+      #   :domain       - String domain for the MX record you wish to change.
+      #   :mxcheck      - String setting to define behavior for the exchanger.
+      #                   Accepted: "auto", "local", "secondary", "remote".
+      #
+      # Returns Hash API response.
+      def set_mx_type(options = {})
+        perform_request({ :api_function => "setmxcheck" }.merge(options))
+      end
+
       # Public: Set mail delivery for a domain.
       #
       # options - Hash options for API call params (default: {}):

--- a/spec/cpanel/email_spec.rb
+++ b/spec/cpanel/email_spec.rb
@@ -269,6 +269,29 @@ module Lumberg
       end
     end
 
+    describe "#delete_mx" do
+      use_vcr_cassette("cpanel/email/delete_mx")
+
+      it "delete an existing mx record" do
+        email.delete_mx(
+          :domain        => domain,
+          :exchange      => "mail.#{domain}",
+          :preference    => 1
+        )[:params][:data][0][:status].should eq(1)
+      end
+    end
+
+    describe "#set_mx_type" do
+      use_vcr_cassette("cpanel/email/set_mx_type")
+
+      it "sets an existing mx record to use remote" do
+        email.set_mx_type(
+          :domain        => domain,
+          :mxcheck       => "remote"
+        )[:params][:data][0][:detected].should  == "remote"
+      end
+    end
+
     describe "#set_mail_delivery" do
       let(:detected) do
         email.mx(:domain => domain)[:params][:data][0][:detected]

--- a/spec/vcr_cassettes/cpanel/email/delete_mx.yml
+++ b/spec/vcr_cassettes/cpanel/email/delete_mx.yml
@@ -1,0 +1,40 @@
+--- 
+recorded_with: VCR 2.0.1
+http_interactions: 
+- request: 
+    method: get
+    uri: https://myhost.com:2087/json-api/cpanel?cpanel_jsonapi_apiversion=2&cpanel_jsonapi_func=delmx&cpanel_jsonapi_module=Email&cpanel_jsonapi_user=lumberg&domain=lumberg-test.com&exchange=mail.lumberg-test.com&preference=1
+    body: 
+      string: ""
+    headers: 
+      Authorization: 
+      - WHM root:iscool
+      Accept: 
+      - "*/*"
+      User-Agent: 
+      - Faraday v0.8.7
+  response: 
+    status: 
+      code: 200
+      message: OK
+    headers: 
+      Date: 
+      - Thu, 30 May 2013 18:15:10 GMT
+      Content-Length: 
+      - "398"
+      Content-Type: 
+      - text/plain; charset="utf-8"
+      Connection: 
+      - Keep-Alive
+      Keep-Alive: 
+      - timeout=70, max=200
+      Server: 
+      - cpsrvd/11.32.6.4
+      X-Keep-Alive-Count: 
+      - "1"
+    body: 
+      string: |
+        {"cpanelresult":{"data":[{"statusmsg":"Bind reloading on rye01 using rndc zone: [lumberg-test.com]\n","status":1,"checkmx":{"detected":"local","local":1,"mxcheck":"auto","remote":0,"secondary":0,"isprimary":1,"changed":1,"warnings":[],"issecondary":0},"results":"Bind reloading on rye01 using rndc zone: [lumberg-test.com]\n"}],"func":"delmx","event":{"result":1},"module":"Email","apiversion":2}}
+
+    http_version: 
+  recorded_at: Thu, 30 May 2013 18:15:11 GMT

--- a/spec/vcr_cassettes/cpanel/email/set_mx_type.yml
+++ b/spec/vcr_cassettes/cpanel/email/set_mx_type.yml
@@ -1,0 +1,40 @@
+--- 
+recorded_with: VCR 2.0.1
+http_interactions: 
+- request: 
+    method: get
+    uri: https://myhost.com:2087/json-api/cpanel?cpanel_jsonapi_apiversion=2&cpanel_jsonapi_func=setmxcheck&cpanel_jsonapi_module=Email&cpanel_jsonapi_user=lumberg&domain=lumberg-test.com&mxcheck=remote
+    body: 
+      string: ""
+    headers: 
+      Accept: 
+      - "*/*"
+      Authorization: 
+      - WHM root:iscool
+      User-Agent: 
+      - Faraday v0.8.7
+  response: 
+    status: 
+      code: 200
+      message: OK
+    headers: 
+      X-Keep-Alive-Count: 
+      - "1"
+      Server: 
+      - cpsrvd/11.32.6.4
+      Date: 
+      - Thu, 30 May 2013 18:16:07 GMT
+      Keep-Alive: 
+      - timeout=70, max=200
+      Connection: 
+      - Keep-Alive
+      Content-Type: 
+      - text/plain; charset="utf-8"
+      Content-Length: 
+      - "428"
+    body: 
+      string: |
+        {"cpanelresult":{"module":"Email","event":{"result":1},"data":[{"statusmsg":"Set Always Accept Status to: remote","status":1,"detected":"remote","remote":1,"secondary":0,"checkmx":{"issecondary":0,"isprimary":0,"detected":"remote","remote":1,"secondary":0,"warnings":[],"local":0,"mxcheck":"remote","changed":1},"local":0,"mxcheck":"remote","results":"Set Always Accept Status to: remote"}],"func":"setmxcheck","apiversion":2}}
+
+    http_version: 
+  recorded_at: Thu, 30 May 2013 18:16:08 GMT


### PR DESCRIPTION
Adds ability to delete mx records via [delmx](http://docs.cpanel.net/twiki/bin/view/ApiDocs/Api2/ApiEmail#Email::delmx) and set the MX server type (auto, secondary, local, remote) via [setmxcheck](http://docs.cpanel.net/twiki/bin/view/ApiDocs/Api2/ApiEmail#Email::setmxcheck).
