### PR TITLE
Rename :key to :response_key

### DIFF
--- a/lib/lumberg/cpanel/base.rb
+++ b/lib/lumberg/cpanel/base.rb
@@ -29,7 +29,7 @@ module Lumberg
       #   :api_function - String API function name to call.
       #   :api_module   - String API module on which API function will be
       #                   called (optional, default: self.class.api_module).
-      #   :key          - String key used to select desired part of API
+      #   :response_key - String key used to select desired part of API
       #                   response (optional, default: "cpanelresult").
       #   :api_username - String account username for API call (optional,
       #                   default: @api_username)
@@ -42,7 +42,7 @@ module Lumberg
 
         api_module = options.delete(:api_module) || self.class.api_module
         params = {
-          :key                       => options.delete(:key) || "cpanelresult",
+          :response_key              => options.delete(:response_key) || "cpanelresult",
           :cpanel_jsonapi_user       => options.delete(:api_username),
           :cpanel_jsonapi_module     => api_module,
           :cpanel_jsonapi_func       => options.delete(:api_function),

--- a/lib/lumberg/whm/account.rb
+++ b/lib/lumberg/whm/account.rb
@@ -42,7 +42,7 @@ module Lumberg
       def change_password(options = {})
         options[:user] = options.delete(:username)
         options[:pass] = options.delete(:password)
-        server.perform_request('passwd', options.merge(:key => 'passwd'))
+        server.perform_request('passwd', options.merge(:response_key => 'passwd'))
       end
 
       # Displays pertinent information about a specific account
@@ -159,7 +159,7 @@ module Lumberg
       # ==== Required
       #  * <tt>:domain</tt> - PENDING
       def domain_user_data(options = {})
-        server.perform_request('domainuserdata', options.merge(:key => 'userdata')) do |s|
+        server.perform_request('domainuserdata', options.merge(:response_key => 'userdata')) do |s|
           s.boolean_params = :hascgi
         end
       end
@@ -196,7 +196,7 @@ module Lumberg
       #  * <tt>:username</tt> - PENDING
       def privs(options ={})
         verify_user(options[:username]) do
-          resp = server.perform_request('myprivs', options.merge(:key => 'privs')) do |s|
+          resp = server.perform_request('myprivs', options.merge(:response_key => 'privs')) do |s|
             s.boolean_params = :all
           end
           # if you get this far, it's successful
@@ -226,7 +226,7 @@ module Lumberg
       #  * <tt>:subs</tt> - PENDING
       def restore_account(options = {})
         options[:user] = options.delete(:username) if options[:username]
-        server.perform_request('restoreaccount', options.merge(:key => 'metadata'))
+        server.perform_request('restoreaccount', options.merge(:response_key => 'metadata'))
       end
 
       protected

--- a/lib/lumberg/whm/cert.rb
+++ b/lib/lumberg/whm/cert.rb
@@ -50,11 +50,7 @@ module Lumberg
       # ==== Optional
       #  * <tt>none</tt> - PENDING
       def installssl(options = {})
-        cert_key = options[:key]
-        # Compensate automatic removal of options[:key]
-        result = server.perform_request('installssl', options) do |serv|
-          serv.instance_variable_get(:@params)[:key] = cert_key
-        end
+        result = server.perform_request('installssl', options)
       end
 
       # List all the domains on the server that have SSL certificates installed
@@ -66,7 +62,7 @@ module Lumberg
       #  * <tt>none</tt> - PENDING
       def listcrts(options = {})
         server.force_response_type = :ssl
-        result = server.perform_request('listcrts', options.merge(:key => 'crt'))
+        result = server.perform_request('listcrts', options.merge(:response_key => 'crt'))
       end
     end
   end

--- a/lib/lumberg/whm/dns.rb
+++ b/lib/lumberg/whm/dns.rb
@@ -37,7 +37,7 @@ module Lumberg
 
       # Generates a list of all domains and corresponding DNS zones associated with your server
       def list_zones(options = {})
-        server.perform_request('listzones', options.merge(:key => 'zone'))
+        server.perform_request('listzones', options.merge(:response_key => 'zone'))
       end
 
       # Return zone records for a domain.
@@ -66,7 +66,7 @@ module Lumberg
       #  * <tt>:domain</tt> - PENDING
       #  * <tt>:"api.version".to_sym</tt> - PENDING
       def resolve_domain(options = {})
-        server.perform_request('resolvedomainname', options.merge(:key => 'data'))
+        server.perform_request('resolvedomainname', options.merge(:response_key => 'data'))
       end
 
       # Allows you to edit a DNS zone record on the server.
@@ -104,7 +104,7 @@ module Lumberg
       # ==== Required
       #  * <tt>:nameserver</tt> - PENDING
       def lookup_nameserver_ip(options = {})
-        server.perform_request('lookupnsip', options.merge(:key => 'ip'))
+        server.perform_request('lookupnsip', options.merge(:response_key => 'ip'))
       end
 
       # Allows you to remove a DNS zone record from the server.
@@ -141,7 +141,7 @@ module Lumberg
       #  * <tt>:preference</tt>    - PENDING
       #  * <tt>:alwaysaccept</tt>  - PENDING
       def change_mx(options = {})
-        server.perform_request('changemx', options.merge(:key => 'data'))
+        server.perform_request('changemx', options.merge(:response_key => 'data'))
       end
 
       # This function will add an MX record to a  specified domain
@@ -152,7 +152,7 @@ module Lumberg
       #  * <tt>:preference</tt>    - PENDING
       #  * <tt>:alwaysaccept</tt>  - PENDING
       def add_mx(options = {})
-        server.perform_request('addmx', options.merge(:key => 'data'))
+        server.perform_request('addmx', options.merge(:response_key => 'data'))
       end
 
       # This function will list a specified domain's MX records
@@ -163,7 +163,7 @@ module Lumberg
       #  * <tt>:domain</tt> - PENDING
       #  * <tt>:"api.version".to_sym</tt> - PENDING
       def list_mxs(options = {})
-        server.perform_request('listmxs', options.merge(:key => 'data'))
+        server.perform_request('listmxs', options.merge(:response_key => 'data'))
       end
 
       # This function will add an MX record

--- a/lib/lumberg/whm/reseller.rb
+++ b/lib/lumberg/whm/reseller.rb
@@ -15,7 +15,7 @@ module Lumberg
       # Lists the usernames of all resellers on the server
       def list
         # This method is funky. That is all
-        result = server.perform_request('listresellers', :key => 'reseller')
+        result = server.perform_request('listresellers', :response_key => 'reseller')
         result[:success] = true
         result[:params]  = {:resellers => result.delete(:params)}
         result
@@ -115,7 +115,7 @@ module Lumberg
       #  * <tt>:username</tt> - PENDING
       def account_counts(options = {})
         options[:user] = options.delete(:username)
-        server.perform_request('acctcounts', options.merge(:key => 'reseller'))
+        server.perform_request('acctcounts', options.merge(:response_key => 'reseller'))
       end
 
       # Defines a reseller's nameservers. Additionally, you may use it to reset a reseller's nameservers to the default settings
@@ -140,7 +140,7 @@ module Lumberg
 
       # Lists the saved reseller ACL lists on the server
       def list_acls
-        server.perform_request('listacls', {:key => 'acls'})
+        server.perform_request('listacls', {:response_key => 'acls'})
       end
 
       # Creates a new reseller ACL list
@@ -148,7 +148,7 @@ module Lumberg
       # ==== Required
       #  * <tt>:acllist</tt> - PENDING
       def save_acl_list(options = {})
-        server.perform_request('saveacllist', options.merge(:key => 'results'))
+        server.perform_request('saveacllist', options.merge(:response_key => 'results'))
       end
 
       # Sets the ACL for a reseller, or modifies specific ACL items for a reseller

--- a/lib/lumberg/whm/server.rb
+++ b/lib/lumberg/whm/server.rb
@@ -64,7 +64,7 @@ module Lumberg
 
       def perform_request(function, options = {})
         # WHM sometime uses different keys for the result hash
-        @key      = options.delete(:key) || 'result'
+        @response_key = options.delete(:response_key) || 'result'
         @function = function
         @params   = format_query(options)
 
@@ -74,11 +74,11 @@ module Lumberg
       end
 
       def get_hostname
-        perform_request('gethostname', {:key => 'hostname'})
+        perform_request('gethostname', {:response_key => 'hostname'})
       end
 
       def version
-        perform_request('version', {:key => 'version'})
+        perform_request('version', {:response_key => 'version'})
       end
 
       def load_average
@@ -89,47 +89,47 @@ module Lumberg
       end
 
       def system_load_average(options = {})
-        perform_request('systemloadavg', options.merge(:key => 'data'))
+        perform_request('systemloadavg', options.merge(:response_key => 'data'))
       end
 
       def languages
-        perform_request('getlanglist', {:key => 'lang'})
+        perform_request('getlanglist', {:response_key => 'lang'})
       end
 
       def list_ips
-        perform_request('listips', {:key => 'result'})
+        perform_request('listips', {:response_key => 'result'})
       end
 
       def add_ip(options = {})
-        perform_request('addip', options.merge(:key => 'addip'))
+        perform_request('addip', options.merge(:response_key => 'addip'))
       end
 
       def delete_ip(options = {})
-        perform_request('delip', options.merge(:key => 'delip'))
+        perform_request('delip', options.merge(:response_key => 'delip'))
       end
 
       def set_hostname(options = {})
-        perform_request('sethostname', options.merge(:key => 'sethostname'))
+        perform_request('sethostname', options.merge(:response_key => 'sethostname'))
       end
 
       def set_resolvers(options = {})
-        perform_request('setresolvers', options.merge(:key => 'setresolvers'))
+        perform_request('setresolvers', options.merge(:response_key => 'setresolvers'))
       end
 
       def show_bandwidth(options = {})
-        perform_request('showbw', options.merge(:key => 'bandwidth'))
+        perform_request('showbw', options.merge(:response_key => 'bandwidth'))
       end
 
       def set_nv_var(options = {})
-        perform_request('nvset', options.merge(:key => 'nvset'))
+        perform_request('nvset', options.merge(:response_key => 'nvset'))
       end
 
       def get_nv_var(options = {})
-        perform_request('nvget', options.merge(:key => 'nvget'))
+        perform_request('nvget', options.merge(:response_key => 'nvget'))
       end
 
       def reboot
-        perform_request('reboot', {:key => "reboot"})
+        perform_request('reboot', {:response_key => "reboot"})
       end
 
       def account
@@ -160,7 +160,7 @@ module Lumberg
 
           c.params = params
           c.request :url_encoded
-          c.response :format_whm, @force_response_type, @key, @boolean_params
+          c.response :format_whm, @force_response_type, @response_key, @boolean_params
           c.response :logger, create_logger_instance
           c.response :json
           c.adapter :net_http

--- a/spec/cpanel/base_spec.rb
+++ b/spec/cpanel/base_spec.rb
@@ -80,9 +80,9 @@ module Lumberg
         it "performs the request with specified key" do
           @base.server.should_receive(:perform_request).with(
             anything,
-            hash_including(:key => "some_key")
+            hash_including(:response_key => "some_key")
           )
-          @base.perform_request(valid_options.merge(:key => "some_key"))
+          @base.perform_request(valid_options.merge(:response_key => "some_key"))
         end
       end
 
@@ -90,7 +90,7 @@ module Lumberg
         it "sets key to \"cpanelresult\"" do
           @base.server.should_receive(:perform_request).with(
             anything,
-            hash_including(:key => "cpanelresult")
+            hash_including(:response_key => "cpanelresult")
           )
           @base.perform_request(valid_options)
         end


### PR DESCRIPTION
Lumberg currently uses :key (within the options hash) to figure out which parameter should be the key of the response. This creates a conflict with the WHM/cPanel calls that require :key 
