### PR TITLE
Update json version to 1.8

### DIFF
--- a/lumberg.gemspec
+++ b/lumberg.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "lumberg"
 
-  s.add_runtime_dependency 'json',               '~> 1.7'
+  s.add_runtime_dependency 'json',               '~> 1.8'
   s.add_runtime_dependency 'faraday',            '~> 0.8.9'
   s.add_runtime_dependency 'faraday_middleware', '~> 0.9.0'
   s.add_runtime_dependency('jruby-openssl', '~> 0.7.3') if RUBY_PLATFORM == 'java'


### PR DESCRIPTION
Updating lumberg's json dependency since Rails `4.1.0` includes `sdoc`, which relies on json `~> 1.8`.
