### PR TITLE
Added functionality to change e-mail account password

### DIFF
--- a/lib/lumberg/cpanel/email.rb
+++ b/lib/lumberg/cpanel/email.rb
@@ -502,6 +502,20 @@ module Lumberg
       def fetchautoresponder(options={})
         perform_request({ api_function: "fetchautoresponder" }.merge(options))
       end
+      
+      # Public: This function changes an email account's password.
+      #
+      # options - Hash options for API call params (default: {}):
+      #  :domain   - String domain for the email address for which you wish
+      #              to change the password.
+      #  :email    - String username for the email address for
+      #              which you wish to change the password.
+      #  :password - String value. The desired password for the account.
+      #
+      # Returns Hash API response
+      def change_password(options={})
+        perform_request({ api_function: "passwdpop" }.merge(options))
+      end
     end
   end
 end

--- a/spec/cpanel/email_spec.rb
+++ b/spec/cpanel/email_spec.rb
@@ -623,5 +623,17 @@ module Lumberg
     describe "#fetchautoresponder" do
       pending
     end
+    
+    describe "#change_password" do
+      use_vcr_cassette("cpanel/email/change_password")
+      
+      it "Modifies the password an e-mail account" do
+        email.change_password(
+          domain:   'myhost.com',
+          email:    'test123@myhost.com',
+          password: 'test123'
+        )[:params][:data].first[:result].should == 1
+      end
+    end
   end
 end

--- a/spec/vcr_cassettes/cpanel/email/change_password.yml
+++ b/spec/vcr_cassettes/cpanel/email/change_password.yml
@@ -1,0 +1,43 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://myhost.com:2087/json-api/cpanel?cpanel_jsonapi_apiversion=2&cpanel_jsonapi_func=passwdpop&cpanel_jsonapi_module=Email&cpanel_jsonapi_user=lumberg&domain=myhost.com&email=test123@myhost.com&password=test123
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - WHM root:"iscool"
+      User-Agent:
+      - Faraday v0.9.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - '*/*'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - cpsrvd/11.42.1.22
+      X-Keep-Alive-Count:
+      - '1'
+      Connection:
+      - Keep-Alive
+      Keep-Alive:
+      - timeout=70, max=200
+      Date:
+      - Mon, 21 Jul 2014 18:09:47 GMT
+      Content-Type:
+      - text/plain; charset="utf-8"
+      Content-Length:
+      - '127'
+    body:
+      encoding: UTF-8
+      string: |
+        {"cpanelresult":{"apiversion":2,"postevent":{"result":1},"preevent":{"result":1},"func":"passwdpop","data":[{"result":1,"reason":""}],"event":{"result":1},"module":"Email"}}
+    http_version: 
+  recorded_at: Mon, 21 Jul 2014 18:09:47 GMT
+recorded_with: VCR 2.9.2


### PR DESCRIPTION
Added method  to change the password of an e-mail account using . 

http://docs.cpanel.net/twiki/bin/view/ApiDocs/Api2/ApiEmail#Email%3a%3apasswdpop

Email::passwdpop
API Version:    2 — Read the documentation for this version.
Description:    This function changes an email account's password.
Parameters: domain (string)
    The domain for the email address for which you wish to change the password. (For example, example.com if the address is user@example.com.)
    email (string)
    The username for the email address for which you wish to change the password. (For example, user if the address is user@example.com.)
    password (string)
    The desired password for the account.
Returns:  
<data>
  <reason> A string value that is undefined if the password is changed successfully, or contains a reason for failure.</reason> 
  <result> A boolean value that indicates success or failure. A value of 1 indicates success. A value of 0 indicates failure.</result>
# </data> 
