### PR TITLE
Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ beta-ish. Please report any issues you find. :)
 
 [RDoc](http://rdoc.info/github/pressednet/lumberg/master/frames)
 
-Confirmed to work with ruby 2.1.3, 2.2.0, 2.3.1 and JRuby 1.9 mode.
+Confirmed to work with Ruby 2.2, 2.3, 2.4, and 2.5.
 
 [Build Status]: https://travis-ci.org/pressednet/lumberg
 [Build Icon]: https://travis-ci.org/pressednet/lumberg.svg?branch=master

--- a/lib/lumberg/version.rb
+++ b/lib/lumberg/version.rb
@@ -1,3 +1,3 @@
 module Lumberg
-  VERSION = '4.1.0'
+  VERSION = '4.2.0'
 end


### PR DESCRIPTION
Bump version for the gem updates in #114. Update the README to note the tested Ruby versions.

Closes #115.
